### PR TITLE
Add analyze_netlogs.py for incident detection in NetWatch and FRITZ!Box logs

### DIFF
--- a/analyze_netlogs.py
+++ b/analyze_netlogs.py
@@ -328,7 +328,7 @@ def main():
                     plt.xlabel("Zeit"); plt.ylabel("ms")
                     plt.tight_layout()
                     plt.savefig(f"latency_{t}.png")
-                plt.close()
+                    plt.close()
             print("📈 Plots gespeichert (latency_*.png).")
         except Exception as e:
             print(f"(Plots übersprungen: {e})")


### PR DESCRIPTION
Ein kompaktes Auswertescript für deine beiden Logs hinzugefügt.

Es erkennt automatisch:
- PC-Seite (netwatch_log.csv): Paketverlust-Bursts, Latenzspitzen je Ziel, DNS-Fehler, Adapter/Media-Statuswechsel, IPv6 an/aus
- FritzBox (fritz_status_log.csv): WAN-Reconnects (Uptime-Reset), externe-IP-Wechsel, Link-Status ≠ Up schreibt Incidents als CSV, plus kurze Konsolen-Zusammenfassung
- optional: einfache Plots (falls matplotlib installiert ist)