### PR TITLE
Add FRITZ!Box WAN/DSL Extended Logger with TR-064 support

### DIFF
--- a/fritzlog_pull_extended.py
+++ b/fritzlog_pull_extended.py
@@ -7,6 +7,7 @@ import csv
 import time
 import argparse
 import datetime
+import os
 
 # Import-Pfad je nach fritzconnection-Version
 try:
@@ -155,8 +156,9 @@ def main():
     ap.add_argument("--user", default=None, help="FRITZ!Box Benutzername")
     ap.add_argument("--password", required=True, help="FRITZ!Box Passwort")
     ap.add_argument("--interval", type=int, default=30, help="Intervall in Sekunden (default: 30)")
-    ap.add_argument("--out", default=r"C:\Tools\fritz_status_log.csv",
-                    help="Pfad zur CSV (default: C:\\Tools\\fritz_status_log.csv)")
+    default_out = os.path.join(os.path.expanduser("~"), "Ping", "Log", "fritz_status_log.csv")
+    ap.add_argument("--out", default=default_out, help=f"Pfad zur CSV (default: {default_out})")
+
     args = ap.parse_args()
 
     header = [


### PR DESCRIPTION
Added extended version with:

- WAN-Status (Connected, Fehler, Uptime, externe IP)
- Common Link Properties (Access-Type, Layer-1 Max Rates, Physical Link)
- Traffic & Raten (Bytes gesamt, aktuelle Sende/Empfangsrate)
- DSL Link (Up/Down)
- DSL Current Rates (aktuelle Sync-Raten)
- DSL Fehlerzähler (CRC/FEC/HEC, Errored Seconds, Retrains, Init-Errors/Timeouts)

Das Script probiert automatisch die verschiedenen Service-Namen (IP/PPP, …1-Suffix etc.) – läuft damit auf sehr vielen Box-Typen (DSL/Kabel/FTTH).